### PR TITLE
Point prompt

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,13 +108,19 @@ def process_image(
 
     molmo_output = get_coords(output, image)
 
-    if type(molmo_output) == str: # If we get image caption instead of points.
+    if type(molmo_output) == str and len(clicked_points) == 0: # If we get image caption instead of points.
         # Clear mouse click prompts after one successful run.
         clicked_points = []
         return  plot_image(image), output, transcribed_text
     
+     # There is a chance the user clicks points and Molmo outputs string. In
+     # that case, we do not want to append the Molmo string output to `coords`
+     # but only the clicked points.
+    if type(molmo_output) != str:
+        coords.extend(molmo_output)
+    
+    # Append the clicked points to `coords`.
     coords.extend(clicked_points)
-    coords.extend(molmo_output)
     
     # Load CLIP and Spacy models if `clip_label` is True.
     if clip_label:
@@ -417,8 +423,7 @@ def get_click_coords(img, evt: gr.SelectData):
     global clicked_points
 
     out = Image.open(img)
-    if len(clicked_points) < 5:
-        clicked_points.append((evt.index[0], evt.index[1]))
+    clicked_points.append((evt.index[0], evt.index[1]))
     
     for point in clicked_points:
         out = draw_circle_on_img(out, point)

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -104,6 +104,7 @@ def get_spacy_output(outputs, model):
         nouns: A list containing the nouns, e.g. ['bird', 'person']
     """
     print(outputs)
+    nouns = ['']
     if 'alt=\"' in outputs:
         match = re.search(r'alt="([^"]*)"', outputs)
         if match:


### PR DESCRIPTION
Added point prompting for images using mouse click.

* Can add a combination of mouse points and text prompt.
* Can only add point prompts without text prompt.
* All other features for the image tab also remain intact in a single tab.